### PR TITLE
Allowing any other meta to be fetch at the same time.

### DIFF
--- a/lib/opengraph.rb
+++ b/lib/opengraph.rb
@@ -9,8 +9,12 @@ module OpenGraph
   #
   # Pass <tt>false</tt> for the second argument if you want to
   # see invalid (i.e. missing a required attribute) data.
-  def self.fetch(uri, strict = true)
-    parse(RestClient.get(uri).body, strict)
+  # 
+  # Pass a block and it will be called on each meta tag to allow
+  # you to fetch them as part of a OpenGraph property (fb:admins
+  # and fb:app_id are among things we may want to retreive).
+  def self.fetch(uri, strict = true, &b)
+    parse(RestClient.get(uri).body, strict, &b)
   rescue RestClient::Exception, SocketError
     false
   end
@@ -22,6 +26,7 @@ module OpenGraph
       if m.attribute('property') && m.attribute('property').to_s.match(/^og:(.+)$/i)
         page[$1.gsub('-','_')] = m.attribute('content').to_s
       end
+      yield m, page if block_given?
     end
     return false if page.keys.empty?
     return false unless page.valid? if strict

--- a/spec/opengraph_spec.rb
+++ b/spec/opengraph_spec.rb
@@ -21,6 +21,27 @@ describe OpenGraph do
       it { subject.title.should == 'Partialized' }
     end
   end
+
+  describe 'being customisable' do
+    it 'should accept a block' do
+      mock_proc = mock
+      mock_proc.should_receive(:bar).
+        with(an_instance_of(Nokogiri::XML::Element), an_instance_of(OpenGraph::Object)).
+        exactly(8).times
+      OpenGraph.parse(rotten) do |meta, page|
+        mock_proc.bar(meta, page)
+      end
+    end
+
+    it 'should be able to fetch fb data with a block' do
+      og = OpenGraph.parse(rotten) do |meta, page|
+        if meta.attribute('property') && meta.attribute('property').to_s.match(/^fb:(.+)$/i)
+          page[$1.gsub('-','_')] = meta.attribute('content').to_s.split(',').map(&:to_i)
+        end
+      end
+      og.admins.should == [1106591]
+    end
+  end
   
   describe '.fetch' do
     it 'should fetch from the specified URL' do


### PR DESCRIPTION
Hi Michael,

This isn't really a push request, in the way that I don't know the functional spectre of the OpenGraph ruby Library.

The feature I needed is to be able to fetch Facebook metadata as well as OpenGraph metadata (fb:admins and fb:app_id). Since I don't want to parse the html two time in a row, once for opengraph properties, another for the Facebook properties, I though it could fit in the opengraph library to be able to fetch another kind of metadata via a custom block.

What do you think ? Is this commit useful ?
## 

Stéphane Akkaoui
